### PR TITLE
SECURITY: Only public subcategories in onebox

### DIFF
--- a/lib/oneboxer.rb
+++ b/lib/oneboxer.rb
@@ -445,8 +445,12 @@ module Oneboxer
   def self.local_category_html(url, route)
     return unless route[:category_slug_path_with_id]
     category = Category.find_by_slug_path_with_id(route[:category_slug_path_with_id])
+    guardian = Guardian.new
 
-    if Guardian.new.can_see_category?(category)
+    if guardian.can_see_category?(category)
+      subcategories =
+        category.subcategories.select { |subcategory| guardian.can_see_category?(subcategory) }
+
       args = {
         url: category.url,
         name: category.name,
@@ -455,7 +459,7 @@ module Oneboxer
         description: Onebox::Helpers.sanitize(category.description),
         has_subcategories: category.subcategories.present?,
         subcategories:
-          category.subcategories.collect { |sc| { name: sc.name, color: sc.color, url: sc.url } },
+          subcategories.collect { |sc| { name: sc.name, color: sc.color, url: sc.url } },
       }
 
       Mustache.render(template("discourse_category_onebox"), args)

--- a/spec/lib/oneboxer_spec.rb
+++ b/spec/lib/oneboxer_spec.rb
@@ -215,6 +215,26 @@ RSpec.describe Oneboxer do
         with_tag("span", with: { class: "hashtag-icon-placeholder" })
       end
     end
+
+    it "does not show private subcategory information" do
+      parent_category = Fabricate(:category)
+      private_subcategory =
+        Fabricate(
+          :private_category,
+          parent_category: parent_category,
+          group: Fabricate(:group, name: "superhero"),
+          name: "Private Subcategory",
+        )
+      public_subcategory =
+        Fabricate(:category, parent_category: parent_category, name: "Public Subcategory")
+
+      preview = preview(parent_category.relative_url)
+      expect(preview).not_to include(private_subcategory.name)
+      expect(preview).not_to include(private_subcategory.url)
+
+      expect(preview).to include(public_subcategory.name)
+      expect(preview).to include(public_subcategory.url)
+    end
   end
 
   describe ".onebox_raw" do


### PR DESCRIPTION
## Summary
- Improve subcategory handling in category oneboxes
- Add proper permission filtering when displaying subcategories
- Include comprehensive test coverage for subcategory visibility

## Test plan
- [x] Verify category oneboxes display correctly
- [x] Test subcategory visibility rules
- [x] Ensure proper permission checks are applied