### PR TITLE
FIX: mark invite accepted notification as read

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -299,8 +299,8 @@ class User < ActiveRecord::Base
     User.where("id = ? and seen_notification_id < ?", id, notification_id)
         .update_all ["seen_notification_id = ?", notification_id]
 
-    # mark all badge notifications read
-    Notification.where('user_id = ? AND NOT read AND notification_type = ?', id, Notification.types[:granted_badge])
+    # mark all "badge granted" and "invite accepted" notifications read
+    Notification.where('user_id = ? AND NOT read AND notification_type IN (?)', id, [Notification.types[:granted_badge], Notification.types[:invitee_accepted]])
         .update_all ["read = ?", true]
   end
 


### PR DESCRIPTION
## Summary
- Fixes issue where invite accepted notifications were not being marked as read
- Updates user model to properly handle notification read status
- Ensures proper cleanup of invite acceptance workflow

## Test plan
- [x] Verify invite notifications are marked as read after acceptance
- [x] Check that notification cleanup works correctly
- [x] Ensure user model handles invite acceptance properly

🤖 Generated with [Claude Code](https://claude.ai/code)