### PR TITLE
BUGFIX: uses markdown instead of HTML when inserting hyperlinked images

### DIFF
--- a/app/assets/javascripts/discourse/views/modal/upload_selector_view.js
+++ b/app/assets/javascripts/discourse/views/modal/upload_selector_view.js
@@ -51,7 +51,7 @@ Discourse.UploadSelectorView = Discourse.ModalBodyView.extend({
         var imageLink = $('#link-input').val();
         var composerView = this.get('controller.composerView');
         if (this.get("controller.showMore") && imageLink.length > 3) {
-          composerView.addMarkdown("<a href='" + imageLink + "'>\n  <img src='" + imageUrl + "'>\n</a>");
+          composerView.addMarkdown("[![](" + imageUrl +")](" + imageLink + ")");
         } else {
           composerView.addMarkdown(imageUrl);
         }


### PR DESCRIPTION
## Summary
- Fixes bug where hyperlinked images were being inserted as HTML instead of markdown
- Updates upload selector view to use proper markdown syntax
- Ensures consistent markdown formatting for linked images
- Improves content rendering and parsing compatibility

## Technical Changes
- Modifies upload_selector_view.js to generate markdown syntax
- Changes from HTML `<a><img></a>` tags to `[\![alt](image)](link)` format
- Ensures proper markdown rendering pipeline compatibility
- Maintains image and link functionality while using standard syntax

## Test plan
- [x] Verify hyperlinked images insert as markdown format
- [x] Check that images with links render correctly 
- [x] Ensure no regression in upload selector functionality
- [x] Test markdown parsing and display consistency

🤖 Generated with [Claude Code](https://claude.ai/code)