### PR TITLE
FIX: moving a post to a topic with a deleted post should use correct post_number. Was getting unique index violation on (topic_id, post_number).

### DIFF
--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -575,7 +575,7 @@ class Topic < ActiveRecord::Base
   end
 
   def max_post_number
-    posts.maximum(:post_number).to_i
+    posts.with_deleted.maximum(:post_number).to_i
   end
 
   def move_posts(moved_by, post_ids, opts)

--- a/spec/models/post_mover_spec.rb
+++ b/spec/models/post_mover_spec.rb
@@ -173,6 +173,36 @@ describe PostMover do
 
       end
 
+      context "to an existing topic with a deleted post" do
+
+        let!(:destination_topic) { Fabricate(:topic, user: user ) }
+        let!(:destination_op) { Fabricate(:post, topic: destination_topic, user: user) }
+        let!(:destination_deleted_reply) { Fabricate(:post, topic: destination_topic, user: another_user) }
+        let(:moved_to) { topic.move_posts(user, [p2.id, p4.id], destination_topic_id: destination_topic.id)}
+
+        it "works correctly" do
+          destination_deleted_reply.trash!
+
+          moved_to.should == destination_topic
+
+          # Check out new topic
+          moved_to.reload
+          moved_to.posts_count.should == 3
+          moved_to.highest_post_number.should == 4
+
+          # Posts should be re-ordered
+          p2.reload
+          p2.sort_order.should == 3
+          p2.post_number.should == 3
+          p2.topic_id.should == moved_to.id
+
+          p4.reload
+          p4.post_number.should == 4
+          p4.sort_order.should == 4
+          p4.topic_id.should == moved_to.id
+        end
+      end
+
 
     end
   end


### PR DESCRIPTION
## Summary
This fix resolves a unique index violation that occurred when moving posts to topics containing deleted posts. The issue was that the system wasn't properly handling post number calculations when deleted posts were present, leading to database constraint violations.

## Changes Made
- **app/models/topic.rb**: Updated post moving logic to correctly calculate post numbers when deleted posts are present
- **spec/models/post_mover_spec.rb**: Added test coverage for the post moving edge case

## Technical Details
The unique index violation occurred on the (topic_id, post_number) constraint when:
1. A topic had deleted posts creating gaps in post numbers
2. New posts were moved to that topic
3. The system tried to assign post numbers that already existed

The fix ensures that post number assignment accounts for deleted posts and maintains database integrity while preserving the logical ordering of posts.

## Problem Resolution
- Prevents unique index violations during post moves
- Maintains correct post numbering sequence
- Ensures database consistency for topic post relationships

🤖 Generated with [Claude Code](https://claude.ai/code)