### PR TITLE
UX: show complete URL path if website domain is same as instance domain

### DIFF
--- a/app/assets/javascripts/discourse/controllers/user.js.es6
+++ b/app/assets/javascripts/discourse/controllers/user.js.es6
@@ -14,12 +14,6 @@ export default ObjectController.extend(CanCheckEmails, {
 
   collapsedInfo: Em.computed.not('indexStream'),
 
-  websiteName: function() {
-    var website = this.get('model.website');
-    if (Em.isEmpty(website)) { return; }
-    return website.split("/")[2];
-  }.property('model.website'),
-
   linkWebsite: Em.computed.not('model.isBasic'),
 
   removeNoFollow: function() {

--- a/app/assets/javascripts/discourse/models/user.js.es6
+++ b/app/assets/javascripts/discourse/models/user.js.es6
@@ -56,7 +56,7 @@ const User = RestModel.extend({
   /**
     This user's profile background(in CSS).
 
-    @property websiteName
+    @property profileBackground
     @type {String}
   **/
   profileBackground: function() {

--- a/app/assets/javascripts/discourse/templates/user/user.hbs
+++ b/app/assets/javascripts/discourse/templates/user/user.hbs
@@ -63,12 +63,12 @@
             {{/if}}
             <h3>
             {{#if model.location}}{{fa-icon "map-marker"}} {{model.location}}{{/if}}
-            {{#if websiteName}}
+            {{#if model.website_name}}
               {{fa-icon "globe"}}
               {{#if linkWebsite}}
-                <a href={{model.website}} rel={{unless removeNoFollow 'nofollow'}} target="_blank">{{websiteName}}</a>
+                <a href={{model.website}} rel={{unless removeNoFollow 'nofollow'}} target="_blank">{{model.website_name}}</a>
               {{else}}
-                <span title={{model.website}}>{{websiteName}}</span>
+                <span title={{model.website}}>{{model.website_name}}</span>
               {{/if}}
             {{/if}}
             </h3>

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -40,6 +40,7 @@ class UserSerializer < BasicUserSerializer
              :bio_cooked,
              :created_at,
              :website,
+             :website_name,
              :profile_background,
              :card_background,
              :location,
@@ -131,6 +132,26 @@ class UserSerializer < BasicUserSerializer
 
   def website
     object.user_profile.website
+  end
+
+  def website_name
+    website_host = URI(website.to_s).host rescue nil
+    discourse_host = Discourse.current_hostname
+    return if website_host.nil?
+    if website_host == discourse_host
+      # example.com == example.com
+      website_host + URI(website.to_s).path
+    elsif (website_host.split('.').length == discourse_host.split('.').length) && discourse_host.split('.').length > 2
+      # www.example.com == forum.example.com
+      website_host.split('.')[1..-1].join('.') == discourse_host.split('.')[1..-1].join('.') ? website_host + URI(website.to_s).path : website_host
+    else
+      # example.com == forum.example.com
+      discourse_host.ends_with?("." << website_host) ? website_host + URI(website.to_s).path : website_host
+    end
+  end
+
+  def include_website_name
+    website.present?
   end
 
   def card_image_badge_id

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -66,11 +66,28 @@ describe UserSerializer do
 
     context "with filled out website" do
       before do
-        user.user_profile.website = 'http://example.com'
+        user.user_profile.website = 'http://example.com/user'
       end
 
       it "has a website" do
-        expect(json[:website]).to eq 'http://example.com'
+        expect(json[:website]).to eq 'http://example.com/user'
+      end
+
+      context "has a website name" do
+        it "returns website host name when instance domain is not same as website domain" do
+          Discourse.stubs(:current_hostname).returns('discourse.org')
+          expect(json[:website_name]).to eq 'example.com'
+        end
+
+        it "returns complete website path when instance domain is same as website domain" do
+          Discourse.stubs(:current_hostname).returns('example.com')
+          expect(json[:website_name]).to eq 'example.com/user'
+        end
+
+        it "returns complete website path when website domain is parent of instance domain" do
+          Discourse.stubs(:current_hostname).returns('forums.example.com')
+          expect(json[:website_name]).to eq 'example.com/user'
+        end
       end
     end
 


### PR DESCRIPTION
## Summary
Improves user experience by displaying the complete URL path when the website domain matches the instance domain, providing better context and clarity for users navigating internal links.

## Technical Details
- Enhances URL display logic for same-domain links
- Shows full path information when domains match
- Improves link visibility and user navigation context

## Impact
- Better user experience for internal navigation
- Clearer indication of internal vs external links
- Improved accessibility and usability

🤖 Generated with [Claude Code](https://claude.ai/code)