### PR TITLE
FEATURE: allow efficient preloading of custom fields in topic list

### DIFF
--- a/app/models/topic_list.rb
+++ b/app/models/topic_list.rb
@@ -3,6 +3,9 @@ require_dependency 'avatar_lookup'
 class TopicList
   include ActiveModel::Serialization
 
+  cattr_accessor :preloaded_custom_fields
+  self.preloaded_custom_fields = []
+
   attr_accessor :more_topics_url,
                 :prev_topics_url,
                 :draft,
@@ -76,6 +79,10 @@ class TopicList
       ft.posters = ft.posters_summary(avatar_lookup: avatar_lookup)
       ft.participants = ft.participants_summary(avatar_lookup: avatar_lookup, user: @current_user)
       ft.topic_list = self
+    end
+
+    if TopicList.preloaded_custom_fields.present?
+      Topic.preload_custom_fields(@topics, TopicList.preloaded_custom_fields)
     end
 
     @topics

--- a/spec/components/topic_query_spec.rb
+++ b/spec/components/topic_query_spec.rb
@@ -320,21 +320,51 @@ describe TopicQuery do
       end
     end
 
+    context 'preload api' do
+      let(:topics) { }
+
+      it "preloads data correctly" do
+        TopicList.preloaded_custom_fields << "tag"
+        TopicList.preloaded_custom_fields << "age"
+        TopicList.preloaded_custom_fields << "foo"
+
+        topic = Fabricate.build(:topic, user: creator, bumped_at: 10.minutes.ago)
+        topic.custom_fields["tag"] = ["a","b","c"]
+        topic.custom_fields["age"] = 22
+        topic.save
+
+        new_topic = topic_query.list_new.topics.first
+
+        expect(new_topic.custom_fields["tag"].sort).to eq(["a","b","c"])
+        expect(new_topic.custom_fields["age"]).to eq("22")
+
+        expect(new_topic.custom_field_preloaded?("tag")).to eq(true)
+        expect(new_topic.custom_field_preloaded?("age")).to eq(true)
+        expect(new_topic.custom_field_preloaded?("foo")).to eq(true)
+        expect(new_topic.custom_field_preloaded?("bar")).to eq(false)
+
+        TopicList.preloaded_custom_fields.clear
+
+        # if we attempt to access non preloaded fields explode
+        expect{new_topic.custom_fields["boom"]}.to raise_error
+
+      end
+    end
+
     context 'with a new topic' do
       let!(:new_topic) { Fabricate(:topic, user: creator, bumped_at: 10.minutes.ago) }
       let(:topics) { topic_query.list_new.topics }
 
 
-      it "contains the new topic" do
-        expect(topics).to eq([new_topic])
-      end
-
       it "contains no new topics for a user that has missed the window" do
+
+        expect(topic_query.list_new.topics).to eq([new_topic])
+
         user.new_topic_duration_minutes = 5
         user.save
         new_topic.created_at = 10.minutes.ago
         new_topic.save
-        expect(topics).to eq([])
+        expect(topic_query.list_new.topics).to eq([])
       end
 
       context "muted topics" do


### PR DESCRIPTION
This PR introduces an efficient preloading mechanism for custom fields in topic lists to avoid N+1 query problems.

## Changes Made

### New Preloading Infrastructure
- Added `preloaded_custom_fields` accessor to HasCustomFields concern
- Implemented `preload_custom_fields` class method for bulk loading
- Added `custom_field_preloaded?` method to check preload status

### Topic List Enhancement
- Added `preloaded_custom_fields` class accessor to TopicList
- Integrated preloading into topic list generation process
- Automatic preloading when fields are configured

### Safety Mechanisms
- Created PreloadedProxy class to prevent mixing preloaded/non-preloaded access
- Strict validation to prevent N+1 queries
- Comprehensive test coverage for the new functionality

## Performance Benefits
- Eliminates N+1 queries when accessing custom fields in topic lists
- Bulk loading reduces database round trips
- Configurable field selection for optimal performance

## Testing
- Added comprehensive test suite covering preload functionality
- Tests verify correct data loading and access restrictions
- Error handling for non-preloaded field access

This change maintains backward compatibility while providing significant performance improvements for custom field access patterns.